### PR TITLE
[ENG-33] Add cross_launch field to Market Map metadata JSON (Redo after changing main branch to Slinky v1.2.0)

### DIFF
--- a/x/marketmap/types/tickermetadata/dydx.go
+++ b/x/marketmap/types/tickermetadata/dydx.go
@@ -16,14 +16,19 @@ type DyDx struct {
 	// AggregateIDs contains a list of AggregatorIDs associated with the ticker.
 	// This field may not be populated if no aggregator currently indexes this Ticker.
 	AggregateIDs []AggregatorID `json:"aggregate_ids"`
+	// CrossLaunch is an optional bool that indicates whether this ticker should be
+	// launched as a cross-margin market (instead of isolated margin).
+	// If omitted, it is set to false by default.
+	CrossLaunch bool `json:"cross_launch,omitempty"`
 }
 
 // NewDyDx returns a new DyDx instance.
-func NewDyDx(referencePrice, liquidity uint64, aggregateIDs []AggregatorID) DyDx {
+func NewDyDx(referencePrice, liquidity uint64, aggregateIDs []AggregatorID, crossLaunch bool) DyDx {
 	return DyDx{
 		ReferencePrice: referencePrice,
 		Liquidity:      liquidity,
 		AggregateIDs:   aggregateIDs,
+		CrossLaunch:    crossLaunch,
 	}
 }
 

--- a/x/marketmap/types/tickermetadata/dydx_test.go
+++ b/x/marketmap/types/tickermetadata/dydx_test.go
@@ -17,6 +17,7 @@ func Test_UnmarshalDyDx(t *testing.T) {
 				tickermetadata.NewAggregatorID("coingecko", "id"),
 				tickermetadata.NewAggregatorID("cmc", "id"),
 			},
+			false,
 		)
 
 		bz, err := tickermetadata.MarshalDyDx(elem)
@@ -28,7 +29,7 @@ func Test_UnmarshalDyDx(t *testing.T) {
 	})
 
 	t.Run("can marshal and unmarshal the same struct and values with empty AggregatorIDs", func(t *testing.T) {
-		elem := tickermetadata.NewDyDx(100, 1000, nil)
+		elem := tickermetadata.NewDyDx(100, 1000, nil, false)
 
 		bz, err := tickermetadata.MarshalDyDx(elem)
 		require.NoError(t, err)
@@ -50,6 +51,39 @@ func Test_UnmarshalDyDx(t *testing.T) {
 				tickermetadata.NewAggregatorID("coingecko", "id"),
 				tickermetadata.NewAggregatorID("cmc", "id"),
 			},
+			false,
+		), elem)
+	})
+
+	t.Run("can unmarshal a JSON string into a struct with empty CrossLaunch field", func(t *testing.T) {
+		elemJSON := `{"reference_price":100,"liquidity":1000,"aggregate_ids":[{"venue":"coingecko","ID":"id"},{"venue":"cmc","ID":"id"}]}`
+		elem, err := tickermetadata.DyDxFromJSONString(elemJSON)
+		require.NoError(t, err)
+
+		require.Equal(t, tickermetadata.NewDyDx(
+			100,
+			1000,
+			[]tickermetadata.AggregatorID{
+				tickermetadata.NewAggregatorID("coingecko", "id"),
+				tickermetadata.NewAggregatorID("cmc", "id"),
+			},
+			false,
+		), elem)
+	})
+
+	t.Run("can unmarshal a JSON string into a struct with CrossLaunch field set", func(t *testing.T) {
+		elemJSON := `{"reference_price":100,"liquidity":1000,"aggregate_ids":[{"venue":"coingecko","ID":"id"},{"venue":"cmc","ID":"id"}],"cross_launch":true}`
+		elem, err := tickermetadata.DyDxFromJSONString(elemJSON)
+		require.NoError(t, err)
+
+		require.Equal(t, tickermetadata.NewDyDx(
+			100,
+			1000,
+			[]tickermetadata.AggregatorID{
+				tickermetadata.NewAggregatorID("coingecko", "id"),
+				tickermetadata.NewAggregatorID("cmc", "id"),
+			},
+			true,
 		), elem)
 	})
 }


### PR DESCRIPTION
* NOTE: This is a redo of https://github.com/dydxprotocol/slinky/pull/1, after changing our main branch to match Skip's v1.2.0 branch of Slinky (before the Connect rename)
* Add new cross_launch field to Market Map metadata JSON, to support cross-margin IML launches
* Field is optional (false by default)
* Add tests for new field